### PR TITLE
Fix spelling and FAQ link to locales

### DIFF
--- a/client/src/components/FAQ.vue
+++ b/client/src/components/FAQ.vue
@@ -144,7 +144,7 @@ const faq = [
       {
         q: 'Contribute.localesQ',
         a: 'Contribute.localesA',
-        par: { link: 'https://github.com/panwauu/tac-locales' },
+        par: { link: 'https://github.com/panwauu/tac-with-bug' },
       },
       {
         q: 'Contribute.bugsQ',

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -907,7 +907,7 @@
       "nGames6": "Beendete Spiele zu 6.:",
       "registeredUsers": "Anzahl der Spieler:",
       "fastestGame": "Schnellstes Spiel:",
-      "averagePlayingTime": "Durschnittliche Spieldauer:",
+      "averagePlayingTime": "Durchschnittliche Spieldauer:",
       "nFriends": "Geschlossene Freundschaften:",
       "nTutorials": "Absolvierte Tutorialschritte:",
       "mostLoved": "Am meisten genutzte Kugel:",
@@ -919,8 +919,8 @@
       "worstTeamGame": "Längstes Team-Tac Spiel:",
       "averageTeamGame": "Durchschnitt der Team-Tac Ergebnisse:"
     },
-    "description1": "Tac-With-Bug ist eine online Mehrspieler Verison des beliebten Brettspiels",
-    "description2": ". Trete gegen Freunde und Fremde zu Viert oder zu Sechst an. Oder spiele Team-Tac und versuche einen neuen Rekord aufzustellen."
+    "description1": "Tac-With-Bug ist eine online Mehrspieler Version des beliebten Brettspiels",
+    "description2": ". Tritt gegen Freunde und Fremde zu viert oder zu sechst an. Oder spiele Team-Tac und versuche einen neuen Rekord aufzustellen."
   },
   "PlayersAutoComplete": {
     "placeholder": "Spieler"


### PR DESCRIPTION
I found a typo in the German translation and, trying to fix it, was not able to locate the right Github repository.